### PR TITLE
Fix build with gcc 11

### DIFF
--- a/main.h
+++ b/main.h
@@ -67,8 +67,8 @@ extern struct fdinfo_t {
 } fdinfo[MAXFD];
 
 
-int kdpfd; /* epoll fd */
-int ss; /* server socket */
+extern int kdpfd; /* epoll fd */
+extern int ss; /* server socket */
     
 extern const char *bind_ip;
 extern int bind_port;


### PR DESCRIPTION
This fixes the build error:

```
/usr/bin/ld: /tmp/ccPsdkFc.o:(.bss+0x4): multiple definition of `kdpfd'; /tmp/ccnGcSmx.o:(.bss+0x4): first defined here
```